### PR TITLE
public HtmlEngine

### DIFF
--- a/PiServerLite.Tests/HtmlFilters/HtmlConditionalFilterTests.cs
+++ b/PiServerLite.Tests/HtmlFilters/HtmlConditionalFilterTests.cs
@@ -1,0 +1,36 @@
+﻿using PiServerLite.Html;
+using Xunit;
+
+namespace PiServerLite.Tests.HtmlFilters
+{
+    public class HtmlConditionalFilterTests
+    {
+        private const string viewKey = "test";
+
+        private readonly HtmlEngine engine;
+
+
+        public HtmlConditionalFilterTests()
+        {
+            var views = new ViewCollection {
+                [viewKey] = "Hello{{#If value}} World{{#EndIf}}!",
+            };
+
+            engine = new HtmlEngine(views);
+        }
+
+        [Fact]
+        public void Inserts_True_Condition()
+        {
+            var html = engine.Process(viewKey, new {value = true});
+            Assert.Equal("Hello World!", html);
+        }
+
+        [Fact]
+        public void Does_Not_Insert_False_Condition()
+        {
+            var html = engine.Process(viewKey, new {value = false});
+            Assert.Equal("Hello!", html);
+        }
+    }
+}

--- a/PiServerLite.Tests/HtmlFilters/HtmlEnumeratorFilterTests.cs
+++ b/PiServerLite.Tests/HtmlFilters/HtmlEnumeratorFilterTests.cs
@@ -1,0 +1,46 @@
+﻿using PiServerLite.Html;
+using Xunit;
+
+namespace PiServerLite.Tests.HtmlFilters
+{
+    public class HtmlEnumeratorFilterTests
+    {
+        private const string viewKey = "test";
+
+        private readonly HtmlEngine engine;
+
+
+        public HtmlEnumeratorFilterTests()
+        {
+            var views = new ViewCollection {
+                [viewKey] = "<{{#Each items.item}}{{item}}{{#EndEach}}>",
+            };
+
+            engine = new HtmlEngine(views);
+        }
+
+        [Fact]
+        public void Insert_0_Items()
+        {
+            var items = new string[0];
+            var html = engine.Process(viewKey, new {items});
+            Assert.Equal("<>", html);
+        }
+
+        [Fact]
+        public void Insert_1_Items()
+        {
+            var items = new[] {"x"};
+            var html = engine.Process(viewKey, new {items});
+            Assert.Equal("<x>", html);
+        }
+
+        [Fact]
+        public void Insert_3_Items()
+        {
+            var items = new[] {"a", "b", "c"};
+            var html = engine.Process(viewKey, new {items});
+            Assert.Equal("<abc>", html);
+        }
+    }
+}

--- a/PiServerLite.Tests/HtmlFilters/HtmlMasterViewFilterTests.cs
+++ b/PiServerLite.Tests/HtmlFilters/HtmlMasterViewFilterTests.cs
@@ -1,0 +1,28 @@
+﻿using PiServerLite.Html;
+using Xunit;
+
+namespace PiServerLite.Tests.HtmlFilters
+{
+    public class HtmlMasterViewFilterTests
+    {
+        private readonly HtmlEngine engine;
+
+
+        public HtmlMasterViewFilterTests()
+        {
+            var views = new ViewCollection {
+                ["test-master"] = "<html>{{master-content}}</html>",
+                ["test-content"] = "{{#master test-master}}Hello World!",
+            };
+
+            engine = new HtmlEngine(views);
+        }
+
+        [Fact]
+        public void Wraps_In_Master_View()
+        {
+            var html = engine.Process("test-content");
+            Assert.Equal("<html>Hello World!</html>", html);
+        }
+    }
+}

--- a/PiServerLite.Tests/HtmlFilters/HtmlScriptFilterTests.cs
+++ b/PiServerLite.Tests/HtmlFilters/HtmlScriptFilterTests.cs
@@ -1,0 +1,28 @@
+﻿using PiServerLite.Html;
+using Xunit;
+
+namespace PiServerLite.Tests.HtmlFilters
+{
+    public class HtmlScriptFilterTests
+    {
+        private readonly HtmlEngine engine;
+
+
+        public HtmlScriptFilterTests()
+        {
+            var views = new ViewCollection {
+                ["test-master"] = "<html>{{$script-content}}</html>",
+                ["test-content"] = "{{#master test-master}}{{#Script}}<script>{{#EndScript}}",
+            };
+
+            engine = new HtmlEngine(views);
+        }
+
+        [Fact]
+        public void Renders_Content_Scripts_In_Master_View()
+        {
+            var html = engine.Process("test-content");
+            Assert.Equal("<html><script></html>", html);
+        }
+    }
+}

--- a/PiServerLite.Tests/HtmlFilters/HtmlStyleFilterTests.cs
+++ b/PiServerLite.Tests/HtmlFilters/HtmlStyleFilterTests.cs
@@ -1,0 +1,28 @@
+﻿using PiServerLite.Html;
+using Xunit;
+
+namespace PiServerLite.Tests.HtmlFilters
+{
+    public class HtmlStyleFilterTests
+    {
+        private readonly HtmlEngine engine;
+
+
+        public HtmlStyleFilterTests()
+        {
+            var views = new ViewCollection {
+                ["test-master"] = "<html>{{$style-content}}</html>",
+                ["test-content"] = "{{#master test-master}}{{#Style}}<style>{{#EndStyle}}",
+            };
+
+            engine = new HtmlEngine(views);
+        }
+
+        [Fact]
+        public void Renders_Content_Styles_In_Master_View()
+        {
+            var html = engine.Process("test-content");
+            Assert.Equal("<html><style></html>", html);
+        }
+    }
+}

--- a/PiServerLite.Tests/HtmlFilters/HtmlUrlFilterTests.cs
+++ b/PiServerLite.Tests/HtmlFilters/HtmlUrlFilterTests.cs
@@ -1,0 +1,31 @@
+﻿using PiServerLite.Html;
+using Xunit;
+
+namespace PiServerLite.Tests.HtmlFilters
+{
+    public class HtmlUrlFilterTests
+    {
+        private const string viewKey = "test";
+
+        private readonly HtmlEngine engine;
+
+
+        public HtmlUrlFilterTests()
+        {
+            var views = new ViewCollection {
+                [viewKey] = "<a href=\"{{#Url /test-path}}\">link</a>",
+            };
+
+            engine = new HtmlEngine(views) {
+                UrlRoot = "server-name",
+            };
+        }
+
+        [Fact]
+        public void Inserts_Url()
+        {
+            var html = engine.Process(viewKey, new {value = true});
+            Assert.Equal("<a href=\"server-name/test-path\">link</a>", html);
+        }
+    }
+}

--- a/PiServerLite/Html/BlockResult.cs
+++ b/PiServerLite/Html/BlockResult.cs
@@ -3,7 +3,7 @@ using System.Text;
 
 namespace PiServerLite.Html
 {
-    internal class BlockResult
+    public class BlockResult
     {
         public StringBuilder Builder {get;}
         public string MasterView {get; set;}

--- a/PiServerLite/Html/Filters/HtmlConditionalFilter.cs
+++ b/PiServerLite/Html/Filters/HtmlConditionalFilter.cs
@@ -1,15 +1,20 @@
 ﻿using System;
 
-namespace PiServerLite.Html.Blocks
+namespace PiServerLite.Html.Filters
 {
-    internal class ConditionalBlock
+    internal class HtmlConditionalFilter : IHtmlTagFilter
     {
         public HtmlEngine Engine {get;}
 
 
-        public ConditionalBlock(HtmlEngine engine)
+        public HtmlConditionalFilter(HtmlEngine engine)
         {
             this.Engine = engine;
+        }
+
+        public bool MatchesTag(string tag)
+        {
+            return tag.StartsWith("#if ", StringComparison.OrdinalIgnoreCase);
         }
 
         public void Process(string text, string tag, VariableCollection valueCollection, BlockResult result, ref int read_pos)

--- a/PiServerLite/Html/Filters/HtmlEachFilter.cs
+++ b/PiServerLite/Html/Filters/HtmlEachFilter.cs
@@ -1,16 +1,21 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace PiServerLite.Html.Blocks
+namespace PiServerLite.Html.Filters
 {
-    internal class EachBlock
+    internal class HtmlEachFilter : IHtmlTagFilter
     {
         public HtmlEngine Engine {get;}
 
 
-        public EachBlock(HtmlEngine engine)
+        public HtmlEachFilter(HtmlEngine engine)
         {
             this.Engine = engine;
+        }
+
+        public bool MatchesTag(string tag)
+        {
+            return tag.StartsWith("#each ", StringComparison.OrdinalIgnoreCase);
         }
 
         public void Process(string text, string tag, VariableCollection valueCollection, BlockResult result, ref int readPos)

--- a/PiServerLite/Html/Filters/HtmlMasterViewFilter.cs
+++ b/PiServerLite/Html/Filters/HtmlMasterViewFilter.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace PiServerLite.Html.Filters
+{
+    internal class HtmlMasterViewFilter : IHtmlTagFilter
+    {
+        public bool MatchesTag(string tag)
+        {
+            return tag.StartsWith("#master ", StringComparison.OrdinalIgnoreCase);
+        }
+
+        public void Process(string text, string tag, VariableCollection valueCollection, BlockResult result, ref int read_pos)
+        {
+            var valueStart = tag.IndexOf(' ');
+            if (valueStart < 0) throw new RenderingException("Master view path is undefined!");
+
+            result.MasterView = tag.Substring(valueStart+1).Trim();
+        }
+    }
+}

--- a/PiServerLite/Html/Filters/HtmlScriptFilter.cs
+++ b/PiServerLite/Html/Filters/HtmlScriptFilter.cs
@@ -1,0 +1,33 @@
+﻿using System;
+
+namespace PiServerLite.Html.Filters
+{
+    internal class HtmlScriptFilter : IHtmlTagFilter
+    {
+        private readonly HtmlEngine engine;
+
+
+        public HtmlScriptFilter(HtmlEngine engine)
+        {
+            this.engine = engine;
+        }
+
+        public bool MatchesTag(string tag)
+        {
+            return string.Equals(tag, "#Script", StringComparison.OrdinalIgnoreCase);
+        }
+
+        public void Process(string text, string tag, VariableCollection valueCollection, BlockResult result, ref int read_pos)
+        {
+            const string endTag = "{{#EndScript}}";
+            var blockEndStart = text.IndexOf(endTag, read_pos, StringComparison.OrdinalIgnoreCase);
+            if (blockEndStart < 0) throw new RenderingException("Ending tag '#EndScript' was not found!");
+
+            var blockText = text.Substring(read_pos, blockEndStart - read_pos);
+            read_pos = blockEndStart + endTag.Length;
+
+            var blockResult = engine.ProcessBlock(blockText, valueCollection);
+            result.Scripts.Add(blockResult.Text);
+        }
+    }
+}

--- a/PiServerLite/Html/Filters/HtmlStyleFilter.cs
+++ b/PiServerLite/Html/Filters/HtmlStyleFilter.cs
@@ -1,0 +1,33 @@
+﻿using System;
+
+namespace PiServerLite.Html.Filters
+{
+    internal class HtmlStyleFilter : IHtmlTagFilter
+    {
+        private readonly HtmlEngine engine;
+
+
+        public HtmlStyleFilter(HtmlEngine engine)
+        {
+            this.engine = engine;
+        }
+
+        public bool MatchesTag(string tag)
+        {
+            return string.Equals(tag, "#Style", StringComparison.OrdinalIgnoreCase);
+        }
+
+        public void Process(string text, string tag, VariableCollection valueCollection, BlockResult result, ref int read_pos)
+        {
+            const string endTag = "{{#EndStyle}}";
+            var blockEndStart = text.IndexOf(endTag, read_pos, StringComparison.OrdinalIgnoreCase);
+            if (blockEndStart < 0) throw new RenderingException("Ending tag '#EndStyle' was not found!");
+
+            var blockText = text.Substring(read_pos, blockEndStart - read_pos);
+            read_pos = blockEndStart + endTag.Length;
+
+            var blockResult = engine.ProcessBlock(blockText, valueCollection);
+            result.Styles.Add(blockResult.Text);
+        }
+    }
+}

--- a/PiServerLite/Html/Filters/HtmlUrlFilter.cs
+++ b/PiServerLite/Html/Filters/HtmlUrlFilter.cs
@@ -1,0 +1,32 @@
+﻿using PiServerLite.Extensions;
+using System;
+
+namespace PiServerLite.Html.Filters
+{
+    internal class HtmlUrlFilter : IHtmlTagFilter
+    {
+        private readonly HtmlEngine engine;
+
+
+        public HtmlUrlFilter(HtmlEngine engine)
+        {
+            this.engine = engine;
+        }
+
+        public bool MatchesTag(string tag)
+        {
+            return tag.StartsWith("#url ", StringComparison.OrdinalIgnoreCase);
+        }
+
+        public void Process(string text, string tag, VariableCollection valueCollection, BlockResult result, ref int read_pos)
+        {
+            var valueStart = tag.IndexOf(' ');
+            if (valueStart < 0) throw new RenderingException("Url path is undefined!");
+
+            var url = tag.Substring(valueStart+1).Trim();
+            url = NetPath.Combine(engine.UrlRoot, url);
+
+            result.Builder.Append(url);
+        }
+    }
+}

--- a/PiServerLite/Html/HtmlTagNotFoundEventArgs.cs
+++ b/PiServerLite/Html/HtmlTagNotFoundEventArgs.cs
@@ -2,13 +2,14 @@
 
 namespace PiServerLite.Html
 {
-    class TagNotFoundEventArgs : EventArgs
+    public class HtmlTagNotFoundEventArgs : EventArgs
     {
         public string Tag {get;}
         public string Result {get; set;}
         public bool Handled {get; set;}
 
-        public TagNotFoundEventArgs(string tag)
+
+        public HtmlTagNotFoundEventArgs(string tag)
         {
             this.Tag = tag;
         }

--- a/PiServerLite/Html/IHtmlTagFilter.cs
+++ b/PiServerLite/Html/IHtmlTagFilter.cs
@@ -1,0 +1,8 @@
+﻿namespace PiServerLite.Html
+{
+    public interface IHtmlTagFilter
+    {
+        bool MatchesTag(string tag);
+        void Process(string text, string tag, VariableCollection valueCollection, BlockResult result, ref int read_pos);
+    }
+}

--- a/PiServerLite/Html/VariableCollection.cs
+++ b/PiServerLite/Html/VariableCollection.cs
@@ -5,7 +5,7 @@ using System.Web;
 
 namespace PiServerLite.Html
 {
-    internal class VariableCollection
+    public class VariableCollection
     {
         private readonly IDictionary<string, object> collection;
 
@@ -25,9 +25,12 @@ namespace PiServerLite.Html
             collection = new Dictionary<string, object>(sourceCollection.collection, StringComparer.OrdinalIgnoreCase);
         }
 
-        public VariableCollection(object parameters)
+        public VariableCollection(object parameters = null)
         {
-            collection = ObjectExtensions.ToDictionary(parameters);
+            collection = parameters == null
+                ? new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase)
+                : parameters as IDictionary<string, object>
+                ?? ObjectExtensions.ToDictionary(parameters);
         }
 
         public virtual bool TryGetFormattedValue(string key, out object value)

--- a/PiServerLite/Http/Handlers/HttpHandlerResult.cs
+++ b/PiServerLite/Http/Handlers/HttpHandlerResult.cs
@@ -261,19 +261,16 @@ namespace PiServerLite.Http.Handlers
         /// <param name="param">Optional view-model object.</param>
         public static HttpHandlerResult View(HttpReceiverContext context, string name, object param = null)
         {
-            if (!context.Views.TryFind(name, out var content))
-                throw new ApplicationException($"View '{name}' was not found!");
-
             var engine = new HtmlEngine(context.Views) {
                 UrlRoot = context.ListenerPath,
             };
 
-            content = engine.Process(content, param);
+            var viewContent = engine.Process(name, param);
 
             return new HttpHandlerResult {
                 StatusCode = (int)HttpStatusCode.OK,
                 StatusDescription = "OK.",
-            }.SetText(content);
+            }.SetText(viewContent);
         }
     }
 }

--- a/PiServerLite/PiServerLite.csproj
+++ b/PiServerLite/PiServerLite.csproj
@@ -3,17 +3,18 @@
     <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>0.4.0</AssemblyVersion>
+    <AssemblyVersion>0.4.1</AssemblyVersion>
     <FileVersion>0.4.0</FileVersion>
-    <Version>0.4.0</Version>
+    <Version>0.4.1</Version>
     <Authors>null511</Authors>
     <Company>Joshua Miller</Company>
-    <Description>A very lightweight HTTP server for the Raspberry Pi using C#.</Description>
+    <Description>A very lightweight HTTP server implementation for .NET written using C#; designed to support low-energy devices, such as the Raspberry Pi.</Description>
     <Copyright>Copyright © Joshua Miller 2018</Copyright>
     <PackageTags>raspberry pi http server lite light</PackageTags>
     <RepositoryUrl>https://github.com/null511/PiServerLite</RepositoryUrl>
     <PackageProjectUrl>https://github.com/null511/PiServerLite</PackageProjectUrl>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <PackageLicenseUrl>https://github.com/null511/PiServerLite/blob/master/LICENSE</PackageLicenseUrl>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
     <Reference Include="System" />

--- a/PiServerLite/ViewCollection.cs
+++ b/PiServerLite/ViewCollection.cs
@@ -10,6 +10,11 @@ namespace PiServerLite
         private readonly ViewCache viewCache;
         private readonly Dictionary<string, Func<string>> viewList;
 
+        public string this[string key] {
+            get => viewList[key]?.Invoke();
+            set => viewList[key] = () => value;
+        }
+
 
         public ViewCollection()
         {


### PR DESCRIPTION
- Make `HtmlEngine` class public so that it can be used for non-server tasks.
- Add an interface for filtering HTML tags, allowing the engines tag-parser to be extended.